### PR TITLE
Improve QuickStart to use git clone and go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is inspired by the [Google-Wide Profiling: A Continuous Profiling I
 
 ### Quickstart
 
-Build conprof binary from the root of the repo directory (requires [bzr](https://bazaar.canonical.com/) and [dot](https://www.graphviz.org/) without `$GOPROXY`):
+Build conprof binary from the root of the repo directory:
 
 ```bash
 git clone git@github.com:conprof/conprof.git

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ This project is inspired by the [Google-Wide Profiling: A Continuous Profiling I
 
 ### Quickstart
 
-Build conprof binary from the root of the repo directory (requires [bzr](https://bazaar.canonical.com/) and [dot](https://www.graphviz.org/)):
+Build conprof binary from the root of the repo directory (requires [bzr](https://bazaar.canonical.com/) and [dot](https://www.graphviz.org/) without `$GOPROXY`):
 
 ```bash
-GO111MODULE=on go get -u github.com/conprof/conprof
+git clone git@github.com:conprof/conprof.git
+GO111MODULE=on GOPROXY=https://proxy.golang.org go install -v
 ```
 
 Run the example:


### PR DESCRIPTION
git cloning and then running go install works, so let's use that in the QuickStart guide.

/cc @brancz @cstyan @LiliC 

Closes #10 

