### PR TITLE
Don't re-use appender after calling Commit()

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -444,7 +444,6 @@ func (sl *scrapeLoop) run(interval, timeout time.Duration, errc chan<- error) {
 	}
 
 	var last time.Time
-	app := sl.appendable.Appender()
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -492,6 +491,7 @@ mainLoop:
 				ls = append(ls, labels.Label{Name: l.Name, Value: l.Value})
 			}
 
+			app := sl.appendable.Appender()
 			_, err := app.Add(ls, timestamp.FromTime(start), buf.Bytes())
 			if err != nil && errc != nil {
 				errc <- err


### PR DESCRIPTION
The [comment on tsdb.Appender](https://github.com/conprof/conprof/blob/ccbcf2069b2abbae7ab2dcb7304c88a2389c36df/vendor/github.com/conprof/tsdb/db.go#L85) says "It must be completed with a call to Commit or Rollback and must not be reused afterwards".

Fixes #34, I believe - the reused Appender would keep resetting the `minTime` on head to its oldest value which prevents anything from being removed.