### PR TITLE
[WIP] Add scrape go trace profile as bytes

### DIFF
--- a/scrape/target.go
+++ b/scrape/target.go
@@ -208,11 +208,11 @@ func (t *Target) Health() TargetHealth {
 // ForProfiles
 func LabelsByProfiles(lset labels.Labels, c *config.ProfilingConfig) []labels.Labels {
 	res := []labels.Labels{}
-	add := func(cfgs ...config.PprofProfilingConfig) {
+	add := func(t string, cfgs ...config.PprofProfilingConfig) {
 		for _, p := range cfgs {
 			if *p.Enabled {
 				l := lset.Copy()
-				l = append(l, labels.Label{Name: ProfilePath, Value: p.Path})
+				l = append(l, labels.Label{Name: ProfilePath, Value: p.Path}, labels.Label{Name: ProfileType, Value: t})
 				res = append(res, l)
 			}
 		}
@@ -220,49 +220,49 @@ func LabelsByProfiles(lset labels.Labels, c *config.ProfilingConfig) []labels.La
 
 	if c.PprofConfig != nil {
 		if c.PprofConfig.Allocs != nil {
-			add(c.PprofConfig.Allocs.PprofProfilingConfig)
+			add(ProfileAllocsType, c.PprofConfig.Allocs.PprofProfilingConfig)
 		}
 	}
 
 	if c.PprofConfig != nil {
 		if c.PprofConfig.Block != nil {
-			add(c.PprofConfig.Block.PprofProfilingConfig)
+			add(ProfileBlockType, c.PprofConfig.Block.PprofProfilingConfig)
 		}
 	}
 
 	if c.PprofConfig != nil {
 		if c.PprofConfig.Goroutine != nil {
-			add(c.PprofConfig.Goroutine.PprofProfilingConfig)
+			add(ProfileGoroutineType, c.PprofConfig.Goroutine.PprofProfilingConfig)
 		}
 	}
 
 	if c.PprofConfig != nil {
 		if c.PprofConfig.Heap != nil {
-			add(c.PprofConfig.Heap.PprofProfilingConfig)
+			add(ProfileGoroutineType, c.PprofConfig.Heap.PprofProfilingConfig)
 		}
 	}
 
 	if c.PprofConfig != nil {
 		if c.PprofConfig.Mutex != nil {
-			add(c.PprofConfig.Mutex.PprofProfilingConfig)
+			add(ProfileMutexType, c.PprofConfig.Mutex.PprofProfilingConfig)
 		}
 	}
 
 	if c.PprofConfig != nil {
 		if c.PprofConfig.Profile != nil {
-			add(c.PprofConfig.Profile.PprofProfilingConfig)
+			add(ProfileProfileType, c.PprofConfig.Profile.PprofProfilingConfig)
 		}
 	}
 
 	if c.PprofConfig != nil {
 		if c.PprofConfig.Threadcreate != nil {
-			add(c.PprofConfig.Threadcreate.PprofProfilingConfig)
+			add(ProfileThreadCreateType, c.PprofConfig.Threadcreate.PprofProfilingConfig)
 		}
 	}
 
 	if c.PprofConfig != nil {
 		if c.PprofConfig.Trace != nil {
-			add(c.PprofConfig.Trace.PprofProfilingConfig)
+			add(ProfileTraceType, c.PprofConfig.Trace.PprofProfilingConfig)
 		}
 	}
 
@@ -277,7 +277,16 @@ func (ts Targets) Less(i, j int) bool { return ts[i].URL().String() < ts[j].URL(
 func (ts Targets) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
 
 const (
-	ProfilePath = "profile_path"
+	ProfilePath             = "profile_path"
+	ProfileType             = "profile_type"
+	ProfileAllocsType       = "allocs"
+	ProfileBlockType        = "block"
+	ProfileGoroutineType    = "goroutine"
+	ProfileHeapType         = "heap"
+	ProfileMutexType        = "mutex"
+	ProfileProfileType      = "profile"
+	ProfileThreadCreateType = "threadcreate"
+	ProfileTraceType        = "trace"
 )
 
 // populateLabels builds a label set from the given label set and scrape configuration.


### PR DESCRIPTION
First part of fixing go trace profiles, we scrape trace profiles and store them as bytes directly, instead of trying to parse them as pprof.

There is some UI work left to do

Ref https://github.com/conprof/conprof/issues/46