### PR TITLE
jsonnet: Allow using configmap instead of secret

### DIFF
--- a/deployments/jsonnet/conprof/conprof.libsonnet
+++ b/deployments/jsonnet/conprof/conprof.libsonnet
@@ -177,4 +177,18 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       },
     },
   },
+
+  withConfigMap:: {
+    local conprof = self,
+
+    configmap:
+      local configmap = k.core.v1.configMap;
+      configmap.new('conprof-config', {}).withData({
+        'conprof.yaml': std.manifestYamlDoc(conprof.config.rawconfig),
+      }) +
+      configmap.mixin.metadata.withNamespace(conprof.config.namespace) +
+      configmap.mixin.metadata.withLabels(conprof.config.commonLabels),
+
+    secret:: null,
+  },
 }


### PR DESCRIPTION
The config only potentially holds secrets, but not in practice (at least in Kubernetes). Some organizations limit actions on secrets and thus prefer configmaps for actual configs.

@metalmatze 