### PR TITLE
Add Profile Type

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -46,9 +46,9 @@ type QueryResult struct {
 }
 
 type Series struct {
-	LabelSet        string  `json:"labelset"`
-	LabelSetEncoded string  `json:"labelsetEncoded"`
-	Timestamps      []int64 `json:"timestamps"`
+	Labels          map[string]string `json:"labels"`
+	LabelSetEncoded string            `json:"labelsetEncoded"`
+	Timestamps      []int64           `json:"timestamps"`
 }
 
 func (a *API) QueryRange(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -95,13 +95,15 @@ func (a *API) QueryRange(w http.ResponseWriter, r *http.Request, ps httprouter.P
 		series := seriesSet.At()
 		ls := series.Labels()
 		filteredLabels := tsdbLabels.Labels{}
+		m := make(map[string]string)
 		for _, l := range ls {
 			if l.Name != "" {
 				filteredLabels = append(filteredLabels, l)
+				m[l.Name] = l.Value
 			}
 		}
 
-		resSeries := Series{LabelSet: filteredLabels.String(), LabelSetEncoded: base64.URLEncoding.EncodeToString([]byte(filteredLabels.String()))}
+		resSeries := Series{Labels: m, LabelSetEncoded: base64.URLEncoding.EncodeToString([]byte(filteredLabels.String()))}
 		i := series.Iterator()
 		for i.Next() {
 			t, _ := i.At()

--- a/config/config.go
+++ b/config/config.go
@@ -70,10 +70,11 @@ func DefaultScrapeConfig() ScrapeConfig {
 					},
 				},
 				Profile: &PprofProfileConfig{
-					PprofProfilingConfig{
+					PprofProfilingConfig: PprofProfilingConfig{
 						Enabled: trueValue(),
 						Path:    "/debug/pprof/profile",
 					},
+					Seconds: 30, // By default Go collects 30s profile.
 				},
 				Threadcreate: &PprofThreadcreateConfig{
 					PprofProfilingConfig{
@@ -82,10 +83,11 @@ func DefaultScrapeConfig() ScrapeConfig {
 					},
 				},
 				Trace: &PprofTraceConfig{
-					PprofProfilingConfig{
+					PprofProfilingConfig: PprofProfilingConfig{
 						Enabled: trueValue(),
 						Path:    "/debug/pprof/trace",
 					},
+					Seconds: 1, // By default Go collects 1s trace.
 				},
 			},
 		},
@@ -200,6 +202,7 @@ type PprofMutexConfig struct {
 
 type PprofProfileConfig struct {
 	PprofProfilingConfig `yaml:",inline"`
+	Seconds              int `yaml:"seconds"`
 }
 
 type PprofThreadcreateConfig struct {
@@ -208,6 +211,7 @@ type PprofThreadcreateConfig struct {
 
 type PprofTraceConfig struct {
 	PprofProfilingConfig `yaml:",inline"`
+	Seconds              int `yaml:"seconds"`
 }
 
 type PprofProfilingConfig struct {

--- a/main.go
+++ b/main.go
@@ -17,13 +17,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
 	"syscall"
-
-	"net/http/pprof"
 
 	"github.com/conprof/conprof/pkg/runutil"
 	"github.com/go-kit/kit/log"

--- a/web/src/model/model.ts
+++ b/web/src/model/model.ts
@@ -17,8 +17,12 @@ export interface QueryResult {
     series: Series[];
 }
 
+export interface Labels {
+  [key: string]: string;
+}
+
 export interface Series {
-    labelset: string;
+    labels: Labels;
     labelsetEncoded: string;
     timestamps: number[];
 }

--- a/web/src/pages/QueryPage.tsx
+++ b/web/src/pages/QueryPage.tsx
@@ -86,6 +86,18 @@ function renderTooltip(props: any) {
     return null;
 }
 
+function formatLabels(labels: { [key: string]: string }) {
+    let tsName = (labels.__name__ || '') + '{';
+    const labelStrings: string[] = [];
+    for (const label in labels) {
+        if (label !== '__name__') {
+            labelStrings.push(label + '="' + labels[label] + '"');
+        }
+    }
+    tsName += labelStrings.join(', ') + '}';
+    return tsName;
+};
+
 function openProfile(props: any) {
     const { payload } = props;
     console.log(props);
@@ -239,7 +251,7 @@ class QueryPage extends React.Component<Props, State> {
                     return (
                     <Grid key={series.labelsetEncoded} item xs={8}>
                         <Paper className={classes.paper}>
-                            <div className={classes.labelSet}>{series.labelset}</div>
+                            <div className={classes.labelSet}>{formatLabels(series.labels)}</div>
                             <div style={{ width: '100%', height: 70 }}>
                                 <ResponsiveContainer>
                                     <ScatterChart height={60} margin={{top: 10, right: 0, bottom: 0, left: 0}}>

--- a/web/web.go
+++ b/web/web.go
@@ -15,9 +15,7 @@
 
 package web
 
-import (
-	"net/http"
-)
+import "net/http"
 
 // Assets contains the project's assets.
 var Assets http.FileSystem = http.Dir("./build")


### PR DESCRIPTION
REF https://github.com/conprof/conprof/issues/46

![image](https://user-images.githubusercontent.com/22289110/82109369-0ec85d00-973e-11ea-8042-7279153642f7.png)

as  we are using special `__name__` label for profile types everything works, with current tsdb setup

Includes:
- Added UI rendering.
- Added Trace parsing, now Traces will be scrapped correctly instead of erroring out.
- Added Seconds argument to Trace/ Profile scrape jobs, which are set to their defaults in Go:

>Profile responds with the pprof-formatted cpu profile. Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified. The package initialization registers it as /debug/pprof/profile. 
>Trace responds with the execution trace in binary form. Tracing lasts for duration specified in seconds GET parameter, or for 1 second if not specified. The package initialization registers it as /debug/pprof/trace. 

