### PR TITLE
Dockerfile: Set workdir early/Update to alpine 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM alpine:3.9
+FROM alpine:3.11
 
-RUN apk add --no-cache graphviz
+WORKDIR /cronprof
 
 COPY conprof                  /bin/conprof
 COPY examples/conprof.yaml    /etc/conprof/config.yaml
 
-RUN mkdir -p /conprof && \
-    chown -R nobody:nogroup etc/conprof /conprof
+RUN apk add --no-cache graphviz \
+&& chown -R nobody:nogroup etc/conprof /conprof
 
 USER       nobody
 EXPOSE     8080
-WORKDIR    /conprof
 ENTRYPOINT [ "/bin/conprof" ]
 CMD        [ "all", \
              "--storage.tsdb.path=/conprof", \


### PR DESCRIPTION
Updates alpine to 3.11 and thus graphviz: 2.40.1-r1 -> 2.42.3-r0

Sets WORKDIR early so the mkdir call is not required.