### PR TITLE
Fix typo on test target

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,7 @@ func TestLoad(t *testing.T) {
 	_, err := Load(`scrape_configs:
 - job_name: 'test'
   static_configs:
-  - targets: ['loaclhost:8080']`)
+  - targets: ['localhost:8080']`)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
From `loaclhost` to `localhost` :smile: 

Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>