### PR TITLE
Fix broken storage connection

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -75,7 +75,7 @@ func registerSampler(m map[string]setupFunc, app *kingpin.Application, name stri
 			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(config)))
 		}
 
-		if bearerToken != nil {
+		if *bearerToken != "" {
 			opts = append(opts, grpc.WithPerRPCCredentials(&perRequestBearerToken{token: *bearerToken}))
 		}
 


### PR DESCRIPTION
The storage API can not be connected with empty token. This should fix it. 