### PR TITLE
scrape manager buffer reload channel

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -43,7 +43,7 @@ func NewManager(logger log.Logger, app Appendable) *Manager {
 		scrapeConfigs: make(map[string]*config.ScrapeConfig),
 		scrapePools:   make(map[string]*scrapePool),
 		graceShut:     make(chan struct{}),
-		triggerReload: make(chan struct{}),
+		triggerReload: make(chan struct{}, 1),
 	}
 }
 


### PR DESCRIPTION
This prevents the scrape reloads from being skipped by the default
case in the select statement, and only takes that branch in the event
a reload is already pending in channel.