### PR TITLE
Extend restart e2e

### DIFF
--- a/pkg/store/client.go
+++ b/pkg/store/client.go
@@ -84,7 +84,7 @@ type grpcSeriesSet struct {
 }
 
 func (s *grpcSeriesSet) Next() bool {
-	if !s.set.Next() {
+	if s.set == nil || !s.set.Next() {
 		return false
 	}
 	l, c := s.set.At()

--- a/test/e2e/e2econprof/services.go
+++ b/test/e2e/e2econprof/services.go
@@ -72,3 +72,22 @@ func NewStorage(sharedDir string, networkName string, name string, dirSuffix str
 
 	return storage, nil
 }
+
+func NewAPI(networkName string, name string, storeAddress string) (*e2e.HTTPService, error) {
+	api := e2e.NewHTTPService(
+		fmt.Sprintf("api-%v", name),
+		DefaultImage(),
+		e2e.NewCommand("api", e2e.BuildArgs(map[string]string{
+			"--debug.name":   fmt.Sprintf("api-%v", name),
+			"--http-address": ":8080",
+			"--log.level":    logLevel,
+			"--store":        storeAddress,
+		})...),
+		e2e.NewHTTPReadinessProbe(8080, "/-/ready", 200, 200),
+		8080,
+	)
+	api.SetUser(strconv.Itoa(os.Getuid()))
+	api.SetBackoff(defaultBackoffConfig)
+
+	return api, nil
+}


### PR DESCRIPTION
This gives us a better representation of what a user might experience as
opposed to just checking against the internal gRPC API result as this is
exactly what the frontend would show.