### PR TITLE
Fix non-continuous series after restart

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -88,7 +88,7 @@ func (a *API) QueryRange(r *http.Request) (interface{}, []error, *ApiError) {
 		return nil, nil, &ApiError{Typ: ErrorBadData, Err: err}
 	}
 
-	set := q.Select(false, nil, sel...)
+	set := q.Select(true, nil, sel...)
 	res := []Series{}
 	for set.Next() {
 		series := set.At()

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -523,6 +524,8 @@ mainLoop:
 
 			tl := sl.target.Labels()
 			tl = append(tl, labels.Label{Name: "__name__", Value: profileType})
+			// Must ensure label-set is sorted
+			sort.Sort(tl)
 			level.Debug(sl.l).Log("msg", "appending new sample", "labels", tl.String())
 
 			app := sl.appendable.Appender(sl.ctx)

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -1,3 +1,16 @@
+// Copyright 2020 The conprof Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (

--- a/test/e2e/e2econprof/services.go
+++ b/test/e2e/e2econprof/services.go
@@ -131,6 +131,25 @@ scrape_configs:
   # Quick scrapes for test purposes.
   scrape_interval: 1s
   scrape_timeout: 1s
+  profiling_config:
+    pprof_config:
+      allocs:
+        enabled: false
+      block:
+        enabled: false
+      goroutine:
+        enabled: false
+      heap:
+        enabled: true
+        path: /debug/pprof/heap
+      mutex:
+        enabled: false
+      profile:
+        enabled: false
+      threadcreate:
+        enabled: false
+      trace:
+        enabled: false
   static_configs:
   - targets: ['localhost:8080']
 `)

--- a/test/e2e/e2econprof/services.go
+++ b/test/e2e/e2econprof/services.go
@@ -15,6 +15,7 @@ package e2econprof
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -90,4 +91,49 @@ func NewAPI(networkName string, name string, storeAddress string) (*e2e.HTTPServ
 	api.SetBackoff(defaultBackoffConfig)
 
 	return api, nil
+}
+
+func NewAll(sharedDir, networkName, name, dirSuffix, config string) (*e2e.HTTPService, error) {
+	dir := filepath.Join(sharedDir, "data", "all", dirSuffix)
+	dataDir := filepath.Join(dir, "data")
+	container := filepath.Join(e2e.ContainerSharedDir, "data", "all", dirSuffix)
+	if err := os.MkdirAll(dataDir, 0777); err != nil {
+		return nil, errors.Wrap(err, "create storage dir")
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "conprof.yaml"), []byte(config), 0666); err != nil {
+		return nil, errors.Wrap(err, "creating conprof config failed")
+	}
+
+	all := e2e.NewHTTPService(
+		fmt.Sprintf("all-%v", name),
+		DefaultImage(),
+		e2e.NewCommand("all", e2e.BuildArgs(map[string]string{
+			"--debug.name":        fmt.Sprintf("storage-%v", name),
+			"--http-address":      ":8080",
+			"--storage.tsdb.path": filepath.Join(container, "data"),
+			"--log.level":         logLevel,
+			"--config.file":       filepath.Join(container, "conprof.yaml"),
+		})...),
+		e2e.NewHTTPReadinessProbe(8080, "/-/ready", 200, 200),
+		8080,
+	)
+	all.SetUser(strconv.Itoa(os.Getuid()))
+	all.SetBackoff(defaultBackoffConfig)
+
+	return all, nil
+}
+
+func DefaultScrapeConfig() string {
+	config := fmt.Sprintf(`
+scrape_configs:
+- job_name: 'conprof'
+  # Quick scrapes for test purposes.
+  scrape_interval: 1s
+  scrape_timeout: 1s
+  static_configs:
+  - targets: ['localhost:8080']
+`)
+
+	return config
 }

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"net/url"
 	"runtime/pprof"
@@ -81,6 +80,8 @@ func TestStorage(t *testing.T) {
 
 		firstSampleSet := []*testSample{}
 
+		startTime := time.Now()
+
 		for i := 0; i < 50; i++ {
 			app := db.Appender(ctx)
 
@@ -93,7 +94,21 @@ func TestStorage(t *testing.T) {
 			}
 			firstSampleSet = append(firstSampleSet, sample)
 
-			_, err = app.Add(labels.FromStrings("__name__", "heap"), sample.timestamp, sample.value)
+			_, err = app.Add(labels.FromStrings(
+				"__name__", "heap",
+				"instance", "localhost:10902",
+				"job", "conprof",
+			), sample.timestamp, sample.value)
+			testutil.Ok(t, err)
+
+			err = app.Commit()
+			testutil.Ok(t, err)
+
+			_, err = app.Add(labels.FromStrings(
+				"__name__", "allocs",
+				"instance", "localhost:10902",
+				"job", "conprof",
+			), sample.timestamp, sample.value)
 			testutil.Ok(t, err)
 
 			err = app.Commit()
@@ -104,7 +119,7 @@ func TestStorage(t *testing.T) {
 
 		err = conn.Close()
 		testutil.Ok(t, err)
-		err = st1.Stop()
+		err = st1.Kill()
 		testutil.Ok(t, err)
 
 		st2, err := e2econprof.NewStorage(d, s.NetworkName(), "2", "test")
@@ -122,7 +137,7 @@ func TestStorage(t *testing.T) {
 
 		secondSampleSet := []*testSample{}
 
-		for i := 0; i < 50; i++ {
+		for i := 0; i < 51; i++ {
 			app := db.Appender(ctx)
 
 			b := bytes.NewBuffer(nil)
@@ -134,7 +149,21 @@ func TestStorage(t *testing.T) {
 			}
 			secondSampleSet = append(secondSampleSet, sample)
 
-			_, err = app.Add(labels.FromStrings("__name__", "heap"), sample.timestamp, sample.value)
+			_, err = app.Add(labels.FromStrings(
+				"__name__", "heap",
+				"instance", "localhost:10902",
+				"job", "conprof",
+			), sample.timestamp, sample.value)
+			testutil.Ok(t, err)
+
+			err = app.Commit()
+			testutil.Ok(t, err)
+
+			_, err = app.Add(labels.FromStrings(
+				"__name__", "allocs",
+				"instance", "localhost:10902",
+				"job", "conprof",
+			), sample.timestamp, sample.value)
 			testutil.Ok(t, err)
 
 			err = app.Commit()
@@ -148,11 +177,16 @@ func TestStorage(t *testing.T) {
 		testutil.Ok(t, s.StartAndWaitReady(a))
 		defer a.Stop()
 
+		q := url.Values{}
+		q.Set("query", "heap{instance=\"localhost:10902\",job=\"conprof\"}")
+		q.Set("from", fmt.Sprintf("%d", timestamp.FromTime(startTime)))
+		q.Set("to", fmt.Sprintf("%d", timestamp.FromTime(time.Now())))
+
 		u := url.URL{
 			Scheme:   "http",
 			Host:     a.HTTPEndpoint(),
 			Path:     "api/v1/query_range",
-			RawQuery: fmt.Sprintf("query=heap&from=%d&to=%d", math.MinInt64, math.MaxInt64),
+			RawQuery: q.Encode(),
 		}
 		resp, err := http.Get(u.String())
 		testutil.Ok(t, err)
@@ -163,17 +197,19 @@ func TestStorage(t *testing.T) {
 
 		testutil.Equals(t, http.StatusOK, resp.StatusCode, string(body))
 
-		res := struct {
-			Status string       `json:"status"`
-			Data   []api.Series `json:"data"`
-		}{}
+		res := queryRangeResult{}
 
 		err = json.Unmarshal(body, &res)
 		testutil.Ok(t, err)
 
 		testutil.Equals(t, 1, len(res.Data), "Unexpected amount of series")
-		testutil.Equals(t, 100, len(res.Data[0].Timestamps), "Unexpected amount of samples")
+		testutil.Equals(t, 101, len(res.Data[0].Timestamps), "Unexpected amount of samples: %s", string(body))
 	})
+}
+
+type queryRangeResult struct {
+	Status string       `json:"status"`
+	Data   []api.Series `json:"data"`
 }
 
 type sample struct {

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/conprof/conprof/api"
 	"github.com/conprof/conprof/pkg/store"
 	"github.com/conprof/conprof/pkg/store/storepb"
 	"github.com/conprof/conprof/test/e2e/e2econprof"
@@ -205,11 +204,6 @@ func TestStorage(t *testing.T) {
 		testutil.Equals(t, 1, len(res.Data), "Unexpected amount of series")
 		testutil.Equals(t, 101, len(res.Data[0].Timestamps), "Unexpected amount of samples: %s", string(body))
 	})
-}
-
-type queryRangeResult struct {
-	Status string       `json:"status"`
-	Data   []api.Series `json:"data"`
 }
 
 type sample struct {


### PR DESCRIPTION
Labels must be consistently sorted at insertion time, so that hashing of
a label-set is consistent.