### PR TITLE
*: Remove trace profile collection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,13 +85,6 @@ func DefaultScrapeConfig() ScrapeConfig {
 						Path:    "/debug/pprof/threadcreate",
 					},
 				},
-				Trace: &PprofTraceConfig{
-					PprofProfilingConfig: PprofProfilingConfig{
-						Enabled: trueValue(),
-						Path:    "/debug/pprof/trace",
-					},
-					Seconds: 1, // By default Go collects 1s trace.
-				},
 			},
 		},
 	}
@@ -181,7 +174,6 @@ type PprofConfig struct {
 	Mutex        *PprofMutexConfig        `yaml:"mutex,omitempty"`
 	Profile      *PprofProfileConfig      `yaml:"profile,omitempty"`
 	Threadcreate *PprofThreadcreateConfig `yaml:"threadcreate,omitempty"`
-	Trace        *PprofTraceConfig        `yaml:"trace,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -262,11 +254,6 @@ type PprofProfileConfig struct {
 
 type PprofThreadcreateConfig struct {
 	PprofProfilingConfig `yaml:",inline"`
-}
-
-type PprofTraceConfig struct {
-	PprofProfilingConfig `yaml:",inline"`
-	Seconds              int `yaml:"seconds"`
 }
 
 type PprofProfilingConfig struct {

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -261,12 +261,6 @@ func LabelsByProfiles(lset labels.Labels, c *config.ProfilingConfig) []labels.La
 		}
 	}
 
-	if c.PprofConfig != nil {
-		if c.PprofConfig.Trace != nil {
-			add(ProfileTraceType, c.PprofConfig.Trace.PprofProfilingConfig)
-		}
-	}
-
 	return res
 }
 
@@ -418,11 +412,6 @@ func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
 			if lbls != nil || origLabels != nil {
 				params := cfg.Params
 				switch profType {
-				case ProfileTraceType:
-					if params == nil {
-						params = url.Values{}
-					}
-					params.Add("seconds", strconv.Itoa(cfg.ProfilingConfig.PprofConfig.Trace.Seconds))
 				case ProfileProfileType:
 					if params == nil {
 						params = url.Values{}

--- a/test/e2e/e2econprof/services.go
+++ b/test/e2e/e2econprof/services.go
@@ -148,8 +148,6 @@ scrape_configs:
         enabled: false
       threadcreate:
         enabled: false
-      trace:
-        enabled: false
   static_configs:
   - targets: ['localhost:8080']
 `)


### PR DESCRIPTION
Until we have a way to display trace profiles we should disable them
from being collected, as the errors cause more confusion than good.