### PR TITLE
api: Deterministic results

### DIFF
--- a/api/flamegraph.go
+++ b/api/flamegraph.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/conprof/conprof/internal/pprof/graph"
@@ -90,6 +91,7 @@ func generateFlamegraphReport(p *profile.Profile, sampleIndex string) (*TreeNode
 		for child := range n.Out {
 			node.Children = append(node.Children, nodeMap[child])
 		}
+		sort.Slice(node.Children, func(i, j int) bool { return node.Children[i].FullName < node.Children[j].FullName })
 	}
 
 	return &TreeNode{

--- a/api/flamegraph_test.go
+++ b/api/flamegraph_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsistentFlamegraph(t *testing.T) {
+	f, err := os.Open("testdata/alloc_objects.pb.gz")
+	require.NoError(t, err)
+	p, err := profile.Parse(f)
+	require.NoError(t, err)
+
+	var res []byte
+
+	for i := 0; i < 100; i++ {
+		root, err := generateFlamegraphReport(p, "")
+		require.NoError(t, err)
+
+		newRes, err := json.Marshal(root)
+		require.NoError(t, err)
+
+		// Just for the first iteration.
+		if res == nil {
+			res = newRes
+			continue
+		}
+
+		if !bytes.Equal(res, newRes) {
+			t.Fatal("Flamegraphs are not generated consistently.")
+		}
+	}
+}


### PR DESCRIPTION
Previously because of map order being random results may have been in random order, which can be confusing.