### PR TITLE
Create configReloaders to synchronize config for api /api/v1/status/config

### DIFF
--- a/api.go
+++ b/api.go
@@ -25,12 +25,13 @@ import (
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/prober"
 	"google.golang.org/grpc"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/conprof/db/storage"
 
 	conprofapi "github.com/conprof/conprof/api"
 	"github.com/conprof/conprof/pkg/store"
 	"github.com/conprof/conprof/pkg/store/storepb"
-	"github.com/conprof/db/storage"
 )
 
 // registerApi registers a API command.

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
+	"github.com/conprof/conprof/config"
 	"github.com/conprof/conprof/pkg/store"
 	"github.com/conprof/conprof/pkg/store/storepb"
 	"github.com/conprof/conprof/pkg/testutil"
@@ -261,7 +263,7 @@ func TestAPILabelNames(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize}
+	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.LabelNames,
@@ -327,7 +329,7 @@ func TestAPILabelValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize}
+	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.LabelValues,
@@ -398,7 +400,7 @@ func TestAPISeries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize}
+	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.Series,

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,14 @@ type Config struct {
 	ScrapeConfigs []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
 }
 
+func (c Config) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("<error creating config string: %s>", err)
+	}
+	return string(b)
+}
+
 // SetDirectory joins any relative file paths with dir.
 func (c *Config) SetDirectory(dir string) {
 	for _, c := range c.ScrapeConfigs {

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -19,12 +19,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/conprof/db/storage"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 
 	"github.com/conprof/conprof/config"
-	"github.com/conprof/db/storage"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 // Appendable returns an Appender.

--- a/store.go
+++ b/store.go
@@ -16,6 +16,8 @@ package main
 import (
 	"time"
 
+	"github.com/conprof/db/tsdb"
+	"github.com/conprof/db/tsdb/wal"
 	"github.com/go-kit/kit/log"
 	"github.com/oklog/run"
 	"github.com/opentracing/opentracing-go"
@@ -27,11 +29,9 @@ import (
 	grpcserver "github.com/thanos-io/thanos/pkg/server/grpc"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/conprof/conprof/pkg/store"
-	"github.com/conprof/db/tsdb"
-	"github.com/conprof/db/tsdb/wal"
 )
 
 type componentString string


### PR DESCRIPTION
A lot of the imports are automatically grouped and sorted by my editor, but should follow the guidelines of this project from what I can see.

I needed to do a bunch of plumbing to pass the configReloaders through all components properly and I think that the individual components registering the `ApplyConfig` is probably cleanest in terms of dependencies.