### PR TITLE
Synchronize all reloaders for the first time

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,6 +177,9 @@ func main() {
 	// Listen for termination signals.
 	g.Add(run.SignalHandler(context.Background(), syscall.SIGINT, syscall.SIGTERM))
 
+	// Synchronize all reloaders for the first time
+	reloadCh <- struct{}{}
+
 	if err := g.Run(); err != nil {
 		level.Error(logger).Log("msg", "running command failed", "err", err)
 		os.Exit(1)


### PR DESCRIPTION
Otherwise the web handler won't have the proper config to serve until a reload is triggered once.
Currently the config handler actually panics. I didn't realize during dev earlier, as I constantly reloaded :grin: 