### PR TITLE
Create http router for api for reusability

### DIFF
--- a/all.go
+++ b/all.go
@@ -61,7 +61,7 @@ func runAll(
 	g *run.Group,
 	mux httpMux,
 	p prober.Probe,
-	reg prometheus.Registerer,
+	reg *prometheus.Registry,
 	logger log.Logger,
 	storagePath,
 	configFile string,

--- a/api/api.go
+++ b/api/api.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"path"
 	"sort"
 	"strconv"
 	"sync"
@@ -29,11 +30,13 @@ import (
 	"github.com/google/pprof/profile"
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
+	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 
 	"github.com/conprof/conprof/config"
 	"github.com/conprof/conprof/internal/pprof/measurement"
@@ -43,6 +46,7 @@ var defaultMetadataTimeRange = 24 * time.Hour
 
 type API struct {
 	logger            log.Logger
+	registry          *prometheus.Registry
 	db                storage.Queryable
 	reloadCh          chan struct{}
 	maxMergeBatchSize int64
@@ -53,16 +57,35 @@ type API struct {
 
 func New(
 	logger log.Logger,
+	registry *prometheus.Registry,
 	db storage.Queryable,
 	reloadCh chan struct{},
 	maxMergeBatchSize int64,
 ) *API {
 	return &API{
 		logger:            logger,
+		registry:          registry,
 		db:                db,
 		reloadCh:          reloadCh,
 		maxMergeBatchSize: maxMergeBatchSize,
 	}
+}
+
+// Routes returns a http.Handler containing all routes of the API so that it can be mounted into a mux.
+func (a *API) Routes(prefix string) http.Handler {
+	r := httprouter.New()
+	r.RedirectTrailingSlash = false
+	ins := extpromhttp.NewInstrumentationMiddleware(a.registry)
+	instr := Instr(a.logger, ins)
+
+	r.GET(path.Join(prefix, "/query_range"), instr("query_range", a.QueryRange))
+	r.GET(path.Join(prefix, "/query"), instr("query", a.Query))
+	r.GET(path.Join(prefix, "/series"), instr("series", a.Series))
+	r.GET(path.Join(prefix, "/labels"), instr("label_names", a.LabelNames))
+	r.GET(path.Join(prefix, "/label/:name/values"), instr("label_values", a.LabelValues))
+	r.GET(path.Join(prefix, "/status/config"), instr("config", a.Config))
+
+	return r
 }
 
 func (a *API) ApplyConfig(c *config.Config) error {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
@@ -263,7 +264,7 @@ func TestAPILabelNames(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
+	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.LabelNames,
@@ -329,7 +330,7 @@ func TestAPILabelValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
+	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.LabelValues,
@@ -400,7 +401,7 @@ func TestAPISeries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
+	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.Series,
@@ -455,5 +456,5 @@ func createFakeGRPCAPI(t *testing.T) (*API, io.Closer) {
 
 	c := storepb.NewReadableProfileStoreClient(conn)
 	q := store.NewGRPCQueryable(c)
-	return New(log.NewNopLogger(), q, make(chan struct{}), DefaultMergeBatchSize), lis
+	return New(log.NewNopLogger(), prometheus.NewRegistry(), q, make(chan struct{}), DefaultMergeBatchSize), lis
 }

--- a/internal/pprof/report/source_test.go
+++ b/internal/pprof/report/source_test.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/conprof/conprof/internal/pprof/binutils"
 	"github.com/google/pprof/profile"
+
+	"github.com/conprof/conprof/internal/pprof/binutils"
 )
 
 func TestWebList(t *testing.T) {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -238,7 +238,7 @@ func TestStore(t *testing.T) {
 	rc := storepb.NewReadableProfileStoreClient(conn)
 	q := NewGRPCQueryable(rc)
 
-	httpapi := api.New(log.NewNopLogger(), q, make(chan struct{}), api.DefaultMergeBatchSize)
+	httpapi := api.New(log.NewNopLogger(), prometheus.NewRegistry(), q, make(chan struct{}), api.DefaultMergeBatchSize)
 
 	req := httptest.NewRequest("GET", "http://example.com/query_range?from=0&to=10&query=allocs", nil)
 


### PR DESCRIPTION
This should make things more maintainable in the future. 
While refactoring this I discovered that I only added the `api/v1/status/config` to _web_ but not _api_...