### PR TITLE
Add /api/v1/targets API

### DIFF
--- a/all.go
+++ b/all.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/conprof/db/tsdb"
 	"github.com/conprof/db/tsdb/wal"
 	"github.com/go-kit/kit/log"
@@ -94,8 +96,12 @@ func runAll(
 		return nil, err
 	}
 
-	err = runWeb(mux, p, reg, logger, db, reloadCh, reloaders, maxMergeBatchSize)
-	if err != nil {
+	w := NewWeb(mux, db, maxMergeBatchSize,
+		WebLogger(logger),
+		WebRegistry(reg),
+		WebReloaders(reloaders),
+	)
+	if err = w.Run(context.TODO(), reloadCh); err != nil {
 		return nil, err
 	}
 

--- a/api.go
+++ b/api.go
@@ -14,18 +14,15 @@
 package main
 
 import (
+	"github.com/conprof/db/storage"
 	"github.com/go-kit/kit/log"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-
-	//"github.com/julienschmidt/httprouter"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/prober"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"gopkg.in/alecthomas/kingpin.v2"
-
-	"github.com/conprof/db/storage"
 
 	conprofapi "github.com/conprof/conprof/api"
 	"github.com/conprof/conprof/pkg/store"
@@ -78,7 +75,7 @@ func runApi(
 	logger = log.With(logger, "component", "api")
 
 	const apiPrefix = "/api/v1/"
-	api := conprofapi.New(logger, reg, db, nil, maxMergeBatchSize)
+	api := conprofapi.New(logger, reg, db, nil, maxMergeBatchSize, conprofapi.NoTargets)
 	mux.Handle(apiPrefix, api.Routes(apiPrefix))
 
 	probe.Ready()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -264,7 +264,7 @@ func TestAPILabelNames(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
+	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, nil, GlobalURLOptions{}, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.LabelNames,
@@ -330,7 +330,7 @@ func TestAPILabelValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
+	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, nil, GlobalURLOptions{}, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.LabelValues,
@@ -401,7 +401,7 @@ func TestAPISeries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, sync.RWMutex{}, &config.Config{}}
+	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, nil, GlobalURLOptions{}, sync.RWMutex{}, &config.Config{}}
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.Series,
@@ -456,5 +456,5 @@ func createFakeGRPCAPI(t *testing.T) (*API, io.Closer) {
 
 	c := storepb.NewReadableProfileStoreClient(conn)
 	q := store.NewGRPCQueryable(c)
-	return New(log.NewNopLogger(), prometheus.NewRegistry(), q, make(chan struct{}), DefaultMergeBatchSize), lis
+	return New(log.NewNopLogger(), prometheus.NewRegistry(), q, make(chan struct{}), DefaultMergeBatchSize, NoTargets), lis
 }

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,7 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/go-sysinfo v1.0.1/go.mod h1:O/D5m1VpYLwGjCYzEt63g3Z1uO3jXfwyzzjiW90t8cY=
 github.com/elastic/go-sysinfo v1.1.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -238,7 +238,7 @@ func TestStore(t *testing.T) {
 	rc := storepb.NewReadableProfileStoreClient(conn)
 	q := NewGRPCQueryable(rc)
 
-	httpapi := api.New(log.NewNopLogger(), prometheus.NewRegistry(), q, make(chan struct{}), api.DefaultMergeBatchSize)
+	httpapi := api.New(log.NewNopLogger(), prometheus.NewRegistry(), q, make(chan struct{}), api.DefaultMergeBatchSize, api.NoTargets)
 
 	req := httptest.NewRequest("GET", "http://example.com/query_range?from=0&to=10&query=allocs", nil)
 

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -25,11 +25,11 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 
 	"github.com/conprof/conprof/config"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
-	"github.com/prometheus/prometheus/pkg/labels"
 )
 
 // TargetHealth describes the health state of a target.

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -22,11 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/conprof/conprof/api"
-	"github.com/conprof/conprof/test/e2e/e2econprof"
 	"github.com/cortexproject/cortex/integration/e2e"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/tsdb/testutil"
+
+	"github.com/conprof/conprof/api"
+	"github.com/conprof/conprof/test/e2e/e2econprof"
 )
 
 func TestAll(t *testing.T) {


### PR DESCRIPTION
I've also restructured how the Sampler and Web component are created to allow for better extensibility in the future. This was needed to be able to pass the `scrape.Manager` to the Web -> API.

Some rough edges that I'm happy to follow up in the future.