### PR TITLE
api: add helper to skip tests if graphviz is missing

### DIFF
--- a/api/svg_test.go
+++ b/api/svg_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSVGRengerer(t *testing.T) {
+func TestSVGRenderer(t *testing.T) {
 	f, err := os.Open("testdata/alloc_objects.pb.gz")
 	require.NoError(t, err)
 	p, err := profile.Parse(f)
@@ -18,8 +18,7 @@ func TestSVGRengerer(t *testing.T) {
 
 	r := NewSVGRenderer(log.NewNopLogger(), p, "")
 	rec := httptest.NewRecorder()
-	err = r.Render(rec)
-	require.NoError(t, err)
+	tryRender(t, r, rec)
 
 	require.Greater(t, len(rec.Body.Bytes()), 0)
 }


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

I ran into this when attempting to package conprof on NixOS. The SVG renderer tests should use dot if it's available, but gracefully degrade if not.