### PR TITLE
Refactor api.New() to take options for optional config

### DIFF
--- a/api.go
+++ b/api.go
@@ -75,7 +75,7 @@ func runApi(
 	logger = log.With(logger, "component", "api")
 
 	const apiPrefix = "/api/v1/"
-	api := conprofapi.New(logger, reg, nil,
+	api := conprofapi.New(logger, reg,
 		conprofapi.WithDB(db),
 		conprofapi.WithMaxMergeBatchSize(maxMergeBatchSize),
 		conprofapi.WithPrefix(apiPrefix),

--- a/api.go
+++ b/api.go
@@ -75,8 +75,12 @@ func runApi(
 	logger = log.With(logger, "component", "api")
 
 	const apiPrefix = "/api/v1/"
-	api := conprofapi.New(logger, reg, db, nil, maxMergeBatchSize, conprofapi.NoTargets)
-	mux.Handle(apiPrefix, api.Routes(apiPrefix))
+	api := conprofapi.New(logger, reg, nil,
+		conprofapi.WithDB(db),
+		conprofapi.WithMaxMergeBatchSize(maxMergeBatchSize),
+		conprofapi.WithPrefix(apiPrefix),
+	)
+	mux.Handle(apiPrefix, api.Routes())
 
 	probe.Ready()
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -35,7 +34,6 @@ import (
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
-	"github.com/conprof/conprof/config"
 	"github.com/conprof/conprof/pkg/store"
 	"github.com/conprof/conprof/pkg/store/storepb"
 	"github.com/conprof/conprof/pkg/testutil"
@@ -269,7 +267,7 @@ func TestAPILabelNames(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, nil, GlobalURLOptions{}, sync.RWMutex{}, &config.Config{}}
+	api := New(log.NewNopLogger(), prometheus.NewRegistry(), WithDB(db))
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.LabelNames,
@@ -335,7 +333,8 @@ func TestAPILabelValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, nil, GlobalURLOptions{}, sync.RWMutex{}, &config.Config{}}
+	//api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, nil, GlobalURLOptions{}, sync.RWMutex{}, &config.Config{}}
+	api := New(log.NewNopLogger(), prometheus.NewRegistry(), WithDB(db))
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.LabelValues,
@@ -406,7 +405,7 @@ func TestAPISeries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := API{log.NewNopLogger(), prometheus.NewRegistry(), db, make(chan struct{}), DefaultMergeBatchSize, nil, GlobalURLOptions{}, sync.RWMutex{}, &config.Config{}}
+	api := New(log.NewNopLogger(), prometheus.NewRegistry(), WithDB(db))
 	var tests = []endpointTestCase{
 		{
 			endpoint: api.Series,
@@ -461,5 +460,5 @@ func createFakeGRPCAPI(t *testing.T) (*API, io.Closer) {
 
 	c := storepb.NewReadableProfileStoreClient(conn)
 	q := store.NewGRPCQueryable(c)
-	return New(log.NewNopLogger(), prometheus.NewRegistry(), q, make(chan struct{}), DefaultMergeBatchSize, NoTargets), lis
+	return New(log.NewNopLogger(), prometheus.NewRegistry(), WithDB(q)), lis
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -238,7 +238,7 @@ func TestStore(t *testing.T) {
 	rc := storepb.NewReadableProfileStoreClient(conn)
 	q := NewGRPCQueryable(rc)
 
-	httpapi := api.New(log.NewNopLogger(), prometheus.NewRegistry(), q, make(chan struct{}), api.DefaultMergeBatchSize, api.NoTargets)
+	httpapi := api.New(log.NewNopLogger(), prometheus.NewRegistry(), api.WithDB(q))
 
 	req := httptest.NewRequest("GET", "http://example.com/query_range?from=0&to=10&query=allocs", nil)
 


### PR DESCRIPTION
/cc @lilic 

Sadly the prefix isn't able to just be done on the outside, as the current routers don't support routing. For that I'd suggest using go-chi/chi in the future.
Still a lot cleaner already.